### PR TITLE
fix precompiled header not found on mixed release

### DIFF
--- a/Engine/Source/ThirdParty/Klawr/ClrHostNative/Klawr.ClrHost.Native.vcxproj
+++ b/Engine/Source/ThirdParty/Klawr/ClrHostNative/Klawr.ClrHost.Native.vcxproj
@@ -86,6 +86,7 @@
       <SDLCheck>true</SDLCheck>
       <ExceptionHandling>false</ExceptionHandling>
       <AdditionalIncludeDirectories>.\Public;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PrecompiledHeaderFile>KlawrClrHostPCH.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>


### PR DESCRIPTION
fix error C2857: '#include' statement specified with the /Ycstdafx.h command-line option was not found in the source file when building.
